### PR TITLE
Add support for custom panic message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,5 +85,20 @@ macro_rules! assert_eq {
                 }
             }
         }
-    })
+    });
+    ($left:expr , $right:expr , $($arg:tt)+) => ({
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let left_dbg = format!("{:?}", *left_val);
+                    let right_dbg = format!("{:?}", *right_val);
+                    let diff = $crate::Changeset::new(&left_dbg, &right_dbg, " ");
+
+                    panic!("assertion failed: `(left == right)` \
+                           (left: `{}`, right: `{}`, diff: `{}`): {}",
+                           left_dbg, right_dbg, diff, format_args!($($arg)+))
+                }
+            }
+        }
+    });
 }

--- a/tests/pretty_assertion.rs
+++ b/tests/pretty_assertion.rs
@@ -17,3 +17,13 @@ fn assert_struct() {
 
     assert_eq!(x, y);
 }
+
+#[test]
+#[should_panic(expected="assertion failed: `(left == right)` (left: `\"Hello World!\"`, right: `\"Hello Wrold!\"`, diff: `\"Hello [91mWorld!\"[0m [92mWrold!\"[0m `): not good: Hello World! != Hello Wrold!")]
+fn assert_args() {
+
+    let x = "Hello World!";
+    let y = "Hello Wrold!";
+
+    assert_eq!(x, y, "not good: {} != {}", x, y);
+}


### PR DESCRIPTION
This makes `pretty_assertions`'s `assert_eq!` fully compatible with rust's `assert_eq!`.