### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn main() {
 
 ## Tip
 
-Specify it as [`[dev-dependency]`](http://doc.crates.io/specifying-dependencies.html#development-dependencies)
+Specify it as [`[dev-dependencies]`](http://doc.crates.io/specifying-dependencies.html#development-dependencies)
 and it will only be used for compiling tests, examples, and benchmarks.
 This way the compile time of `cargo build` won't be affected!
 


### PR DESCRIPTION
The TOML section to add the crate as a dependency is `[dev-dependencies]`, not `[dev-dependency]`.

Closes #6.