### PR TITLE
 #10 - assert_eq! too strict with strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub struct Comparison {
 }
 
 impl Comparison {
-    pub fn new<T: Debug>(left: &T, right: &T) -> Comparison {
+    pub fn new<TLeft: Debug, TRight: Debug>(left: &TLeft, right: &TRight) -> Comparison {
         let left_dbg = format!("{:?}", *left);
         let right_dbg = format!("{:?}", *right);
         let changeset = Changeset::new(&left_dbg, &right_dbg, " ");

--- a/tests/assert_eq.rs
+++ b/tests/assert_eq.rs
@@ -46,3 +46,10 @@ fn assert_eq_custom() {
 
     assert_eq!(x, y, "custom panic message");
 }
+
+#[test]
+fn assert_eq_with_comparable_types() {
+	let s0: &'static str = "foo";
+	let s1: String = "foo".to_string();
+	assert_eq!(s0, s1);
+}


### PR DESCRIPTION
Fixes #10. Ensure that assert_eq can compile with comparable types.