### PR TITLE
Allow assert_ne!() in functions returning values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,40 +129,38 @@ macro_rules! __assert_ne {
     ($left:expr, $right:expr, $maybe_semicolon:expr, $($arg:tt)+) => ({
         match (&($left), &($right)) {
             (left_val, right_val) => {
-                if *left_val != *right_val {
-                    return;
+                if *left_val == *right_val {
+                  let left_dbg = format!("{:?}", *left_val);
+                  let right_dbg = format!("{:?}", *right_val);
+                  if left_dbg != right_dbg {
+
+                      panic!("assertion failed: `(left != right)`{}{}\
+                            \n\
+                            \n{}\
+                            \n{}: According to the `PartialEq` implementation, both of the values \
+                              are partially equivalent, even if the `Debug` outputs differ.\
+                            \n\
+                            \n",
+                             $maybe_semicolon,
+                             format_args!($($arg)+),
+                             $crate::Comparison::new(left_val, right_val),
+                             $crate::Style::new()
+                                 .bold()
+                                 .underline()
+                                 .paint("Note"))
+                  }
+
+                  panic!("assertion failed: `(left != right)`{}{}\
+                        \n\
+                        \n{}:\
+                        \n{:#?}\
+                        \n\
+                        \n",
+                         $maybe_semicolon,
+                         format_args!($($arg)+),
+                         $crate::Style::new().bold().paint("Both sides"),
+                         left_val)
                 }
-
-                let left_dbg = format!("{:?}", *left_val);
-                let right_dbg = format!("{:?}", *right_val);
-                if left_dbg != right_dbg {
-
-                    panic!("assertion failed: `(left != right)`{}{}\
-                          \n\
-                          \n{}\
-                          \n{}: According to the `PartialEq` implementation, both of the values \
-                            are partially equivalent, even if the `Debug` outputs differ.\
-                          \n\
-                          \n",
-                           $maybe_semicolon,
-                           format_args!($($arg)+),
-                           $crate::Comparison::new(left_val, right_val),
-                           $crate::Style::new()
-                               .bold()
-                               .underline()
-                               .paint("Note"))
-                }
-
-                panic!("assertion failed: `(left != right)`{}{}\
-                      \n\
-                      \n{}:\
-                      \n{:#?}\
-                      \n\
-                      \n",
-                       $maybe_semicolon,
-                       format_args!($($arg)+),
-                       $crate::Style::new().bold().paint("Both sides"),
-                       left_val)
             }
         }
     });

--- a/tests/assert_ne.rs
+++ b/tests/assert_ne.rs
@@ -60,6 +60,16 @@ fn assert_ne_custom() {
 }
 
 #[test]
+#[should_panic]
+fn assert_ne_non_empty_return() {
+    fn not_zero(x: u32) -> u32 {
+        assert_ne!(x, 0);
+        x
+    };
+    not_zero(0);
+}
+
+#[test]
 #[should_panic(expected=r#"assertion failed: `(left != right)`
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :


### PR DESCRIPTION
Using `assert_ne!()` in a function that returns not `()` fails to build. This happens when functions use `assert!()` and friends for checks (e.g. preconditions) instead of strictly unit tests.

This PR fixes that and adds a small test case to demonstrate the issue and verify that the change works. The change just inverts an `if` and removes a `return`. I tested this with my project (where I encountered the issue) and it seems to work, but it would be nice to hear that this works on something larger with more diverse tests.

Example of a (relatively unimaginative) function which fails to build today:
```rust
fn not_zero(x: u32) -> u32 {
    assert_ne!(x, 0);
    x
};
```

(As an aside, the changes are much easier to glance over with `git diff -w`, since most of the changes are in indentation)