### PR TITLE
Add trailing comma support in macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ impl Display for Comparison {
 
 #[macro_export]
 macro_rules! assert_eq {
+    ($left:expr , $right:expr,) => ({
+        assert_eq!($left, $right)
+    });
     ($left:expr , $right:expr) => ({
         match (&($left), &($right)) {
             (left_val, right_val) => {
@@ -169,6 +172,9 @@ macro_rules! __assert_ne {
 #[macro_export]
 macro_rules! assert_ne {
     ($left:expr, $right:expr) => ({
+        __assert_ne!($left, $right, "", "");
+    });
+    ($left:expr, $right:expr,) => ({
         __assert_ne!($left, $right, "", "");
     });
     ($left:expr, $right:expr, $($arg:tt)+) => ({

--- a/tests/assert_eq.rs
+++ b/tests/assert_eq.rs
@@ -98,3 +98,67 @@ fn issue12() {
     let right = vec![84, 248, 45, 64];
     assert_eq!(left, right);
 }
+
+#[test]
+#[should_panic(expected=r#"assertion failed: `(left == right)`
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+ Some(
+     Foo {
+[31m<[0m[31m        lorem: "Hello W[0m[1;48;5;52;31mo[0m[31mr[0m[31mld!",[0m
+[32m>[0m[32m        lorem: "Hello W[0m[32mr[0m[1;48;5;22;32mo[0m[32mld!",[0m
+         ipsum: 42,
+         dolor: Ok(
+[31m<[0m[31m            "hey[0m[31m"[0m
+[32m>[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m"[0m
+         )
+     }
+ )
+
+"#)]
+fn assert_eq_trailing_comma() {
+
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo { lorem: "Hello World!", ipsum: 42, dolor: Ok("hey".to_string())});
+    let y = Some(Foo { lorem: "Hello Wrold!", ipsum: 42, dolor: Ok("hey ho!".to_string())});
+
+    assert_eq!(x, y,);
+}
+
+#[test]
+#[should_panic(expected=r#"assertion failed: `(left == right)`: custom panic message
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+ Some(
+     Foo {
+[31m<[0m[31m        lorem: "Hello W[0m[1;48;5;52;31mo[0m[31mr[0m[31mld!",[0m
+[32m>[0m[32m        lorem: "Hello W[0m[32mr[0m[1;48;5;22;32mo[0m[32mld!",[0m
+         ipsum: 42,
+         dolor: Ok(
+[31m<[0m[31m            "hey[0m[31m"[0m
+[32m>[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m"[0m
+         )
+     }
+ )
+
+"#)]
+fn assert_eq_custom_trailing_comma() {
+
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo { lorem: "Hello World!", ipsum: 42, dolor: Ok("hey".to_string())});
+    let y = Some(Foo { lorem: "Hello Wrold!", ipsum: 42, dolor: Ok("hey ho!".to_string())});
+
+    assert_eq!(x, y, "custom panic message",);
+}

--- a/tests/assert_ne.rs
+++ b/tests/assert_ne.rs
@@ -83,3 +83,61 @@ fn assert_ne_non_empty_return() {
 fn assert_ne_partial() {
     assert_ne!(-0.0, 0.0);
 }
+
+#[test]
+#[should_panic(expected=r#"assertion failed: `(left != right)`
+
+[1mBoth sides[0m:
+Some(
+    Foo {
+        lorem: "Hello World!",
+        ipsum: 42,
+        dolor: Ok(
+            "hey"
+        )
+    }
+)
+
+"#)]
+fn assert_ne_trailing_comma() {
+
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo { lorem: "Hello World!", ipsum: 42, dolor: Ok("hey".to_string())});
+
+    assert_ne!(x, x,);
+}
+
+#[test]
+#[should_panic(expected=r#"assertion failed: `(left != right)`: custom panic message
+
+[1mBoth sides[0m:
+Some(
+    Foo {
+        lorem: "Hello World!",
+        ipsum: 42,
+        dolor: Ok(
+            "hey"
+        )
+    }
+)
+
+"#)]
+fn assert_ne_custom_trailing_comma() {
+
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo { lorem: "Hello World!", ipsum: 42, dolor: Ok("hey".to_string())});
+
+    assert_ne!(x, x, "custom panic message",);
+}


### PR DESCRIPTION
This resolves #16. I've added tests as well.