### PR TITLE
Update ansi-term.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ travis-ci = { repository = "colin-kiegel/rust-pretty-assertions" }
 
 [dependencies]
 difference = "2.0.0"
-ansi_term = "0.10"
+ansi_term = "0.11"


### PR DESCRIPTION
This fixes some warnings when building docs with the updated
markdown renderer.