### PR TITLE
Fix panic with custom Debug impl returning an empty string

### DIFF
--- a/src/format_changeset.rs
+++ b/src/format_changeset.rs
@@ -36,7 +36,7 @@ pub fn format_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::R
                 }
             }
             Difference::Add(ref added) => {
-                match diffs.get(i - 1) {
+                match diffs.get(i.wrapping_sub(1)) {
                     Some(&Difference::Rem(ref removed)) => {
                         // The addition is preceded by an removal.
                         //

--- a/tests/pretty_string.rs
+++ b/tests/pretty_string.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate pretty_assertions;
+
+use std::fmt;
+/// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
+/// Used in different `assert*!` macros in combination with `pretty_assertions` crate to make
+/// test failures to show nice diffs.
+#[derive(PartialEq, Eq)]
+#[doc(hidden)]
+pub struct PrettyString<'a>(pub &'a str);
+
+/// Make diff to display string as multi-line string
+impl<'a> fmt::Debug for PrettyString<'a> {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    f.write_str(self.0)
+  }
+}
+
+#[test]
+#[should_panic(expected = r#"assertion failed: `(left == right)`
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+[32m>foo
+[0m
+"#)]
+fn assert_eq_empty_first() {
+    assert_eq!(PrettyString(""), PrettyString("foo"));
+}


### PR DESCRIPTION
I tried to use the idea posted in #24 by @idubrov.

When running:

    assert_eq!(PrettyString(""), PrettyString("foo"));

I got a panic 'attempt to subtract with overflow'. This PR fixes it.