### PR TITLE
Fix ANSI colors in Windows CMD and PowerShell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ travis-ci = { repository = "colin-kiegel/rust-pretty-assertions" }
 [dependencies]
 difference = "2.0.0"
 ansi_term = "0.11"
-output_vt100 = { git = "https://github.com/Phundrak/output-vt100-rs", branch = "master" }
+output_vt100 = "0.1.0"
 ctor = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ travis-ci = { repository = "colin-kiegel/rust-pretty-assertions" }
 [dependencies]
 difference = "2.0.0"
 ansi_term = "0.11"
+output_vt100 = { git = "https://github.com/Phundrak/output-vt100-rs", branch = "master" }
+ctor = "0.1.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! When writing tests in Rust, you'll probably use `assert_eq!(a, b)` _a lot_.
 //!
-//! If such a test fails, it will present all the details of `a` and `b`. 
+//! If such a test fails, it will present all the details of `a` and `b`.
 //! But you have to spot the differences yourself, which is not always straightforward,
 //! like here:
 //!
@@ -67,6 +67,8 @@
 
 extern crate difference;
 extern crate ansi_term;
+extern crate output_vt100;
+extern crate ctor;
 mod format_changeset;
 
 use std::fmt::{self, Debug, Display};
@@ -74,6 +76,12 @@ use difference::Changeset;
 
 use format_changeset::format_changeset;
 pub use ansi_term::Style;
+
+use ctor::*;
+#[ctor]
+fn init() {
+    output_vt100::init();
+}
 
 #[doc(hidden)]
 pub struct Comparison(Changeset);


### PR DESCRIPTION
Hi there!

This is a fix for the issue #15. Turns out CMD and PowerShell both support ANSI colors, but it is disabled by default and it can be enabled with the correct system calls. And that’s basically what the crate [output_vt100](https://crates.io/crates/output_vt100) does, which I’ve just released.

I also made the `output_vt100::init()` function (which activates the escaped characters for Windows) to be called at launch for any crate calling `pretty_assertions` thanks to the crate [ctor](https://crates.io/crates/ctor), but maybe it should be made optional?