### PR TITLE
Prevent fail on Windows builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ difference = "2.0.0"
 ansi_term = "0.11"
 
 [target.'cfg(windows)'.dependencies]
-output_vt100 = "0.1"
+output_vt100 = "0.1.2"
 ctor = "0.1.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ use ctor::*;
 #[cfg(windows)]
 #[ctor]
 fn init() {
-    output_vt100::init();
+    output_vt100::try_init().ok(); // Do not panic on fail
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
This fixes issue #29.
Sorry for the inconvenience.

This makes output_vt100 silently fails when an error occurs while getting the standard output handle.