### PR TITLE
Use stringified expressions instead of `left` and `right`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,10 +117,12 @@ macro_rules! assert_eq {
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
-                    panic!("assertion failed: `(left == right)`\
+                    panic!("assertion failed: `({} == {})`\
                           \n\
                           \n{}\
                           \n",
+                           stringify!($left),
+                           stringify!($right),
                            $crate::Comparison::new(left_val, right_val))
                 }
             }
@@ -130,10 +132,12 @@ macro_rules! assert_eq {
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
-                    panic!("assertion failed: `(left == right)`: {}\
+                    panic!("assertion failed: `({} == {})`: {}\
                           \n\
                           \n{}\
                           \n",
+                           stringify!($left),
+                           stringify!($right),
                            format_args!($($arg)*),
                            $crate::Comparison::new(left_val, right_val))
                 }
@@ -161,13 +165,15 @@ macro_rules! assert_ne {
                   let right_dbg = format!("{:?}", *right_val);
                   if left_dbg != right_dbg {
 
-                      panic!("assertion failed: `(left != right)`{}{}\
+                      panic!("assertion failed: `({} != {})`{}{}\
                             \n\
                             \n{}\
                             \n{}: According to the `PartialEq` implementation, both of the values \
                               are partially equivalent, even if the `Debug` outputs differ.\
                             \n\
                             \n",
+                             stringify!($left),
+                             stringify!($right),
                              $maybe_semicolon,
                              format_args!($($arg)+),
                              $crate::Comparison::new(left_val, right_val),
@@ -177,12 +183,14 @@ macro_rules! assert_ne {
                                  .paint("Note"))
                   }
 
-                  panic!("assertion failed: `(left != right)`{}{}\
+                  panic!("assertion failed: `({} != {})`{}{}\
                         \n\
                         \n{}:\
                         \n{:#?}\
                         \n\
                         \n",
+                         stringify!($left),
+                         stringify!($right),
                          $maybe_semicolon,
                          format_args!($($arg)+),
                          $crate::Style::new().bold().paint("Both sides"),

--- a/tests/assert_eq.rs
+++ b/tests/assert_eq.rs
@@ -3,7 +3,7 @@ use pretty_assertions::{assert_eq, assert_ne};
 extern crate difference;
 
 #[test]
-#[should_panic(expected = r#"assertion failed: `(left == right)`
+#[should_panic(expected = r#"assertion failed: `(x == y)`
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(
@@ -43,7 +43,7 @@ fn assert_eq() {
 
 #[test]
 #[should_panic(
-    expected = r#"assertion failed: `(left == right)`: custom panic message
+    expected = r#"assertion failed: `(x == y)`: custom panic message
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(
@@ -115,7 +115,7 @@ fn issue12() {
 }
 
 #[test]
-#[should_panic(expected = r#"assertion failed: `(left == right)`
+#[should_panic(expected = r#"assertion failed: `(x == y)`
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(
@@ -155,7 +155,7 @@ fn assert_eq_trailing_comma() {
 
 #[test]
 #[should_panic(
-    expected = r#"assertion failed: `(left == right)`: custom panic message
+    expected = r#"assertion failed: `(x == y)`: custom panic message
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(

--- a/tests/assert_ne.rs
+++ b/tests/assert_ne.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use pretty_assertions::{assert_eq, assert_ne};
 #[test]
-#[should_panic(expected = r#"assertion failed: `(left != right)`
+#[should_panic(expected = r#"assertion failed: `(x != x)`
 
 [1mBoth sides[0m:
 Some(
@@ -34,7 +34,7 @@ fn assert_ne() {
 
 #[test]
 #[should_panic(
-    expected = r#"assertion failed: `(left != right)`: custom panic message
+    expected = r#"assertion failed: `(x != x)`: custom panic message
 
 [1mBoth sides[0m:
 Some(
@@ -77,7 +77,7 @@ fn assert_ne_non_empty_return() {
 }
 
 #[test]
-#[should_panic(expected = r#"assertion failed: `(left != right)`
+#[should_panic(expected = r#"assertion failed: `(Foo(-0.0) != Foo(0.0))`
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
 [31m<[0m[1;48;5;52;31m-[0m[31m0.0[0m
@@ -108,7 +108,7 @@ fn assert_ne_partial() {
 }
 
 #[test]
-#[should_panic(expected = r#"assertion failed: `(left != right)`
+#[should_panic(expected = r#"assertion failed: `(x != x)`
 
 [1mBoth sides[0m:
 Some(
@@ -141,7 +141,7 @@ fn assert_ne_trailing_comma() {
 
 #[test]
 #[should_panic(
-    expected = r#"assertion failed: `(left != right)`: custom panic message
+    expected = r#"assertion failed: `(x != x)`: custom panic message
 
 [1mBoth sides[0m:
 Some(

--- a/tests/pretty_string.rs
+++ b/tests/pretty_string.rs
@@ -16,7 +16,7 @@ impl<'a> fmt::Debug for PrettyString<'a> {
 }
 
 #[test]
-#[should_panic(expected = r#"assertion failed: `(left == right)`
+#[should_panic(expected = r#"assertion failed: `(PrettyString("") == PrettyString("foo"))`
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
 [32m>foo


### PR DESCRIPTION
Hi and thanks for the helpful library!
I was annoyed a few times now by the panic message only showing `(left == right)` instead of my actual arguments to the `assert_eq` call and had to add a custom message describing the arguments.
This change also helps in remembering which side was the expected or the actual value (which happens to me...)

Slightly ugly things in this MR:

------
The following message is duplicated 4 times:
```
assertion failed: `({} == {})`
```
------
Some existing tests now also verify this new feature, I think it would be slightly prettier to make these tests also pass `x` and `y` as arguments (so they don't check two things at once) and make a new test verify this new feature