### PR TITLE
internal: replace difference with diffus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ readme = "README.md"
 travis-ci = { repository = "colin-kiegel/rust-pretty-assertions" }
 
 [dependencies]
-difference = "2.0.0"
 ansi_term = "0.11.0"
+diffus = "0.9.1"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"

--- a/src/format_changeset.rs
+++ b/src/format_changeset.rs
@@ -1,10 +1,15 @@
-use ansi_term::Colour::{Fixed, Green, Red};
-use ansi_term::Style;
-use difference::{Changeset, Difference};
+use ansi_term::{
+    Colour::{Fixed, Green, Red},
+    Style,
+};
+use diffus::{
+    edit::{self, collection, string},
+    Diffable,
+};
 use std::fmt;
 
 macro_rules! paint {
-    ($f:ident, $colour:expr, $fmt:expr, $($args:tt)*) => (
+    ($f:expr, $colour:expr, $fmt:expr, $($args:tt)*) => (
         write!($f, "{}", $colour.paint(format!($fmt, $($args)*)))
     )
 }
@@ -16,8 +21,11 @@ const SIGN_LEFT: char = '<'; // - < ←
 // https://github.com/johannhof/difference.rs/blob/c5749ad7d82aa3d480c15cb61af9f6baa08f116f/examples/github-style.rs
 // Credits johannhof (MIT License)
 
-pub fn format_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::Result {
-    let ref diffs = changeset.diffs;
+/// Present the diff output for two mutliline strings in a pretty, colorised manner.
+pub(crate) fn format_changeset(f: &mut fmt::Formatter, left: &str, right: &str) -> fmt::Result {
+    let left: Vec<&str> = left.split("\n").collect();
+    let right: Vec<&str> = right.split("\n").collect();
+    let diff = left.diff(&right);
 
     writeln!(
         f,
@@ -26,19 +34,36 @@ pub fn format_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::R
         Red.paint(format!("{} left", SIGN_LEFT)),
         Green.paint(format!("right {}", SIGN_RIGHT))
     )?;
+
+    match diff {
+        edit::Edit::Copy(lines) => {
+            // If the whole debug string is the same, just pad and print one of them
+            for line in lines {
+                writeln!(f, " {}", line)?;
+            }
+        }
+        edit::Edit::Change(diffs) => {
+            // Otherwise, format and write the changes we are given
+            format_change_diffs(f, diffs)?;
+        }
+    };
+    Ok(())
+}
+
+/// Internal details of how we format the `diffus` changes given to us.
+fn format_change_diffs(
+    f: &mut fmt::Formatter,
+    diffs: Vec<collection::Edit<'_, &str, Vec<string::Edit>>>,
+) -> fmt::Result {
     for i in 0..diffs.len() {
         match diffs[i] {
-            Difference::Same(ref same) => {
-                // Have to split line by line in order to have the extra whitespace
-                // at the beginning.
-                for line in same.split('\n') {
-                    writeln!(f, " {}", line)?;
-                }
+            collection::Edit::Copy(ref same) => {
+                writeln!(f, " {}", same)?;
             }
-            Difference::Add(ref added) => {
+            collection::Edit::Insert(ref added) => {
                 let prev = i.checked_sub(1).and_then(|x| diffs.get(x));
                 match prev {
-                    Some(&Difference::Rem(ref removed)) => {
+                    Some(&collection::Edit::Remove(ref removed)) => {
                         // The addition is preceded by an removal.
                         //
                         // Let's highlight the character-differences in this replaced
@@ -46,115 +71,133 @@ pub fn format_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::R
                         format_replacement(f, added, removed)?;
                     }
                     _ => {
-                        for line in added.split('\n') {
-                            paint!(f, Green, "{}{}\n", SIGN_RIGHT, line)?;
-                        }
+                        paint!(f, Green, "{}{}", SIGN_RIGHT, added)?;
+                        // write trailing newline outide of styling
+                        writeln!(f)?;
                     }
                 };
             }
-            Difference::Rem(ref removed) => {
+            collection::Edit::Remove(ref removed) => {
                 let next = i.checked_add(1).and_then(|x| diffs.get(x));
                 match next {
-                    Some(&Difference::Add(_)) => {
+                    Some(&collection::Edit::Insert(_)) => {
                         // The removal is followed by an addition.
                         //
                         // ... we'll handle both in the next iteration.
                     }
                     _ => {
-                        for line in removed.split('\n') {
-                            paint!(f, Red, "{}{}\n", SIGN_LEFT, line)?;
-                        }
+                        paint!(f, Red, "{}{}", SIGN_LEFT, removed)?;
+                        // write trailing newline outide of styling
+                        writeln!(f)?;
                     }
                 }
+            }
+            collection::Edit::Change(..) => {
+                panic!("`Change`s only occur for nested `struct`s, which Vec<&str> is not.")
             }
         }
     }
     Ok(())
 }
 
-macro_rules! join {
-    (
-        $elem:ident in ($iter:expr) {
-            $( $body:tt )*
-        } seperated by {
-            $( $separator:tt )*
-        }
-    ) => (
-        let mut iter = $iter;
-
-        if let Some($elem) = iter.next() {
-            $( $body )*
-        }
-
-        for $elem in iter {
-            $( $separator )*
-            $( $body )*
-        }
-    )
+/// Group character styling for an inline diff, to prevent wrapping each single
+/// character in terminal styling codes.
+///
+/// Styles are applied automatically each time a new style is given in `write_with_style`.
+struct InlineWriter<'a, Writer> {
+    f: &'a mut Writer,
+    style: Style,
 }
 
-pub fn format_replacement(f: &mut dyn fmt::Write, added: &str, removed: &str) -> fmt::Result {
-    let Changeset { diffs, .. } = Changeset::new(removed, added, "");
-
-    // LEFT side (==what's been)
-    paint!(f, Red, "{}", SIGN_LEFT)?;
-    for c in &diffs {
-        match *c {
-            Difference::Same(ref word_diff) => {
-                join!(chunk in (word_diff.split('\n')) {
-                    paint!(f, Red, "{}", chunk)?;
-                } seperated by {
-                    writeln!(f)?;
-                    paint!(f, Red, "{}", SIGN_LEFT)?;
-                });
-            }
-            Difference::Rem(ref word_diff) => {
-                join!(chunk in (word_diff.split('\n')) {
-                    paint!(f, Red.on(Fixed(52)).bold(), "{}", chunk)?;
-                } seperated by {
-                    writeln!(f)?;
-                    paint!(f, Red.bold(), "{}", SIGN_LEFT)?;
-                });
-            }
-            _ => (),
-        }
-    }
-    writeln!(f, "")?;
-
-    // RIGHT side (==what's new)
-    paint!(f, Green, "{}", SIGN_RIGHT)?;
-    for c in &diffs {
-        match *c {
-            Difference::Same(ref word_diff) => {
-                join!(chunk in (word_diff.split('\n')) {
-                    paint!(f, Green, "{}", chunk)?;
-                } seperated by {
-                    writeln!(f)?;
-                    paint!(f, Green, "{}", SIGN_RIGHT)?;
-                });
-            }
-            Difference::Add(ref word_diff) => {
-                join!(chunk in (word_diff.split('\n')) {
-                    paint!(f, Green.on(Fixed(22)).bold(), "{}", chunk)?;
-                } seperated by {
-                    writeln!(f)?;
-                    paint!(f, Green.bold(), "{}", SIGN_RIGHT)?;
-                });
-            }
-            _ => (),
+impl<'a, Writer> InlineWriter<'a, Writer>
+where
+    Writer: fmt::Write,
+{
+    fn new(f: &'a mut Writer) -> Self {
+        InlineWriter {
+            f,
+            style: Style::new(),
         }
     }
 
-    writeln!(f, "")
+    /// Push a new character into the buffer, specifying the style it should be written in.
+    fn write_with_style(&mut self, c: char, style: Style) -> fmt::Result {
+        // If the style is the same as previously, just write character
+        if style == self.style {
+            write!(self.f, "{}", c)?;
+        } else {
+            // Close out previous style
+            write!(self.f, "{}", self.style.suffix())?;
+
+            // Store new style and start writing it
+            write!(self.f, "{}{}", style.prefix(), c)?;
+            self.style = style;
+        }
+        Ok(())
+    }
+
+    /// Push a new character into the buffer, specifying the style it should be written in.
+    fn finish_line(&mut self) -> fmt::Result {
+        // Close out previous style
+        write!(self.f, "{}\n", self.style.suffix())?;
+        self.style = Default::default();
+        Ok(())
+    }
+}
+
+/// Format a single line to show an inline diff of the two strings given.
+///
+/// The given strings should be the output of a line diff, i.e. should contain no newline `\n`
+/// characters.
+///
+/// The output of this function will be two lines, each with a trailing newline.
+fn format_replacement<TWrite: fmt::Write>(
+    f: &mut TWrite,
+    added: &str,
+    removed: &str,
+) -> fmt::Result {
+    let diff = removed.diff(added);
+    match diff {
+        edit::Edit::Copy(_) => {
+            // If for some reason we get two strings the same, just plain print them
+            writeln!(f, " {}", added)?;
+        }
+        edit::Edit::Change(diffs) => {
+            // LEFT side (==what's been)
+            let light = Red.into();
+            let heavy = Red.on(Fixed(52)).bold();
+            let mut writer = InlineWriter::new(f);
+            writer.write_with_style(SIGN_LEFT, light)?;
+            for c in &diffs {
+                match *c {
+                    string::Edit::Copy(c) => writer.write_with_style(c, light)?,
+                    string::Edit::Remove(c) => writer.write_with_style(c, heavy)?,
+                    _ => (),
+                }
+            }
+            writer.finish_line()?;
+
+            // RIGHT side (==what's new)
+            let light = Green.into();
+            let heavy = Green.on(Fixed(22)).bold();
+            writer.write_with_style(SIGN_RIGHT, light)?;
+            for c in &diffs {
+                match *c {
+                    string::Edit::Copy(c) => writer.write_with_style(c, light)?,
+                    string::Edit::Insert(c) => writer.write_with_style(c, heavy)?,
+                    _ => (),
+                }
+            }
+            writer.finish_line()?;
+        }
+    }
+    Ok(())
 }
 
 #[test]
 fn test_format_replacement() {
-    let added = "    84,\
-                 \n    248,";
-    let removed = "    0,\
-                   \n    0,\
-                   \n    128,";
+    let added = "    84,";
+    let removed = "    128,";
 
     let mut buf = String::new();
     let _ = format_replacement(&mut buf, added, removed);
@@ -169,8 +212,21 @@ fn test_format_replacement() {
         removed, added, buf
     );
 
+    let red_light = "\u{1b}[31m";
+    let green_light = "\u{1b}[32m";
+    let red_heavy = "\u{1b}[1;48;5;52;31m";
+    let green_heavy = "\u{1b}[1;48;5;22;32m";
+    let reset = "\u{1b}[0m";
+
     assert_eq!(
         buf,
-        "\u{1b}[31m<\u{1b}[0m\u{1b}[31m    \u{1b}[0m\u{1b}[1;48;5;52;31m0\u{1b}[0m\u{1b}[31m,\u{1b}[0m\n\u{1b}[31m<\u{1b}[0m\u{1b}[31m    \u{1b}[0m\u{1b}[1;48;5;52;31m0,\u{1b}[0m\n\u{1b}[1;31m<\u{1b}[0m\u{1b}[1;48;5;52;31m    1\u{1b}[0m\u{1b}[31m2\u{1b}[0m\u{1b}[31m8,\u{1b}[0m\n\u{1b}[32m>\u{1b}[0m\u{1b}[32m    \u{1b}[0m\u{1b}[1;48;5;22;32m84\u{1b}[0m\u{1b}[32m,\u{1b}[0m\n\u{1b}[32m>\u{1b}[0m\u{1b}[32m    \u{1b}[0m\u{1b}[32m2\u{1b}[0m\u{1b}[1;48;5;22;32m4\u{1b}[0m\u{1b}[32m8,\u{1b}[0m\n"
+        format!(
+            "{red_light}<    {reset}{red_heavy}12{reset}{red_light}8,{reset}\n{green_light}>    8{reset}{green_heavy}4{reset}{green_light},{reset}\n",
+            red_light=red_light,
+            green_light=green_light,
+            red_heavy=red_heavy,
+            green_heavy=green_heavy,
+            reset=reset,
+        ),
     );
 }

--- a/tests/assert_eq.rs
+++ b/tests/assert_eq.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use pretty_assertions::{assert_eq, assert_ne};
-extern crate difference;
 
 #[test]
 #[should_panic(expected = r#"assertion failed: `(left == right)`
@@ -8,12 +7,12 @@ extern crate difference;
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(
      Foo {
-[31m<[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
-[32m>[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+[31m<        lorem: "Hello W[0m[1;48;5;52;31mo[0m[31mrld!",[0m
+[32m>        lorem: "Hello Wr[0m[1;48;5;22;32mo[0m[32mld!",[0m
          ipsum: 42,
          dolor: Ok(
-[31m<[0m[31m            "hey[0m[31m",[0m
-[32m>[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+[31m<            "hey",[0m
+[32m>            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
          ),
      },
  )
@@ -48,12 +47,12 @@ fn assert_eq() {
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(
      Foo {
-[31m<[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
-[32m>[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+[31m<        lorem: "Hello W[0m[1;48;5;52;31mo[0m[31mrld!",[0m
+[32m>        lorem: "Hello Wr[0m[1;48;5;22;32mo[0m[32mld!",[0m
          ipsum: 42,
          dolor: Ok(
-[31m<[0m[31m            "hey[0m[31m",[0m
-[32m>[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+[31m<            "hey",[0m
+[32m>            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
          ),
      },
  )
@@ -93,17 +92,31 @@ fn assert_eq_with_comparable_types() {
 #[should_panic(expected = r#"assertion failed: `(left == right)`
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
+[31m<[0m[1;48;5;52;31m9[0m
+[32m>[0m[1;48;5;22;32m8[0m
+
+"#)]
+fn inline_diff_simple() {
+    let left = 9;
+    let right = 8;
+    assert_eq!(left, right);
+}
+
+#[test]
+#[should_panic(expected = r#"assertion failed: `(left == right)`
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
  [
-[31m<[0m[31m    [0m[1;48;5;52;31m0[0m[31m,[0m
-[31m<[0m[31m    [0m[1;48;5;52;31m0,[0m
-[1;31m<[0m[1;48;5;52;31m    0,[0m
-[1;31m<[0m[1;48;5;52;31m    1[0m[31m2[0m[31m8,[0m
-[31m<[0m[31m    [0m[1;48;5;52;31m10,[0m
-[1;31m<[0m[1;48;5;52;31m    191,[0m
-[1;31m<[0m[1;48;5;52;31m    [0m[31m5,[0m
-[32m>[0m[32m    [0m[1;48;5;22;32m84[0m[32m,[0m
-[32m>[0m[32m    [0m[32m2[0m[1;48;5;22;32m4[0m[32m8,[0m
-[32m>[0m[32m    [0m[1;48;5;22;32m4[0m[32m5,[0m
+[31m<    0,[0m
+[31m<    0,[0m
+[31m<    0,[0m
+[31m<    128,[0m
+[31m<    10,[0m
+[31m<    191,[0m
+[31m<    [0m[1;48;5;52;31m5[0m[31m,[0m
+[32m>    [0m[1;48;5;22;32m84[0m[32m,[0m
+[32m>    248,[0m
+[32m>    45,[0m
      64,
  ]
 
@@ -120,12 +133,12 @@ fn issue12() {
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(
      Foo {
-[31m<[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
-[32m>[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+[31m<        lorem: "Hello W[0m[1;48;5;52;31mo[0m[31mrld!",[0m
+[32m>        lorem: "Hello Wr[0m[1;48;5;22;32mo[0m[32mld!",[0m
          ipsum: 42,
          dolor: Ok(
-[31m<[0m[31m            "hey[0m[31m",[0m
-[32m>[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+[31m<            "hey",[0m
+[32m>            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
          ),
      },
  )
@@ -160,12 +173,12 @@ fn assert_eq_trailing_comma() {
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
  Some(
      Foo {
-[31m<[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
-[32m>[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+[31m<        lorem: "Hello W[0m[1;48;5;52;31mo[0m[31mrld!",[0m
+[32m>        lorem: "Hello Wr[0m[1;48;5;22;32mo[0m[32mld!",[0m
          ipsum: 42,
          dolor: Ok(
-[31m<[0m[31m            "hey[0m[31m",[0m
-[32m>[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+[31m<            "hey",[0m
+[32m>            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
          ),
      },
  )

--- a/tests/assert_ne.rs
+++ b/tests/assert_ne.rs
@@ -81,7 +81,7 @@ fn assert_ne_non_empty_return() {
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
 [31m<[0m[1;48;5;52;31m-[0m[31m0.0[0m
-[32m>[0m[32m0.0[0m
+[32m>0.0[0m
 
 [1;4mNote[0m: According to the `PartialEq` implementation, both of the values are partially equivalent, even if the `Debug` outputs differ.
 

--- a/tests/pretty_string.rs
+++ b/tests/pretty_string.rs
@@ -19,8 +19,9 @@ impl<'a> fmt::Debug for PrettyString<'a> {
 #[should_panic(expected = r#"assertion failed: `(left == right)`
 
 [1mDiff[0m [31m< left[0m / [32mright >[0m :
-[32m>foo
-[0m
+[31m<[0m
+[32m>[0m[1;48;5;22;32mfoo[0m
+
 "#)]
 fn assert_eq_empty_first() {
     assert_eq!(PrettyString(""), PrettyString("foo"));


### PR DESCRIPTION
As per issue #44, the `difference` crate is unmaintained. This PR implements using [`diffus`](https://crates.io/crates/diffus) to replace the underlying diffing functionality, as proposed by @brightly-salty

I also considered the `dissimilar` and `similar` crates, but they do not support line-diffing which is required for the current behaviour of `pretty_assertions` (it requires both line and character level diffing).

These changes are non-breaking for the documented macros/structs in the [current documentation](https://docs.rs/pretty_assertions/0.6.1/pretty_assertions/), but **breaking** for public undocumented functions/structs.  Literal terminal output may also slightly differ due to the underlying algorithm changing, and the way text is styled.

**I would suggest this is released as a minor (breaking) version bump to be on the safe side.**

### This PR

```bash
cargo run --example pretty_assertion
```

![image](https://user-images.githubusercontent.com/12255914/106637299-6a5fa280-657a-11eb-97a0-ea3aaa271335.png)


### master

```bash
cargo run --example pretty_assertion
```

![image](https://user-images.githubusercontent.com/12255914/106637273-616ed100-657a-11eb-99a1-19d10f8a1f26.png)




Closes #44