### PR TITLE
ci: make travis fail on audit failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,17 @@ rust:
   - beta
   - stable
   - 1.35.0
+script: cargo test
 
-# run only one job first to see if it fails, then run the rest
+# run only one comprehensive job first to see if it fails
+# then run the rest of the build matrix with simple tests
 jobs:
   include:
     - stage: fast-test
       os: linux
       rust: stable
-      # additional behaviour just for this comprehensive job
-      before_install: |
-        rustup component add rustfmt clippy
-        cargo install cargo-audit cargo-tarpaulin
-      script: |
-        cargo fmt -- --check
-        cargo audit --deny warnings
-        cargo clippy --all-targets -- -D warnings
-        cargo test
-        cargo doc --no-deps
+      before_install: ./scripts/install
+      script: ./scripts/check
       after_success: |
         cargo tarpaulin --out xml
         bash <(curl -s https://codecov.io/bash)

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+cargo fmt -- --check
+cargo audit --deny warnings \
+  --ignore RUSTSEC-2020-0095
+cargo clippy --all-targets -- -D warnings
+cargo test
+cargo doc --no-deps

--- a/scripts/install
+++ b/scripts/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+rustup component add rustfmt clippy
+cargo install cargo-audit cargo-tarpaulin


### PR DESCRIPTION
For #46 

- make sure the build fails correctly if any check fails
- ignore the existing `difference` audit warning
- break out installation and checking as scripts