### PR TITLE
Test and fix macro hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Support for unsized values (#42, @stanislav-tkach)
 
+## Fixed
+
+- Fix some unhygenic macro expansions (#41, @tommilligan)
+
 ## Internal
 
 - Test Windows targets in CI (#46, @tommilligan)

--- a/examples/pretty_assertion.rs
+++ b/examples/pretty_assertion.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
-use pretty_assertions::{assert_eq, assert_ne};
+use pretty_assertions::assert_eq;
 
 include!("standard_assertion.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl Display for Comparison {
 #[macro_export]
 macro_rules! assert_eq {
     ($left:expr , $right:expr,) => ({
-        assert_eq!($left, $right)
+        $crate::assert_eq!($left, $right)
     });
     ($left:expr , $right:expr) => ({
         match (&($left), &($right)) {
@@ -148,13 +148,13 @@ macro_rules! assert_eq {
 #[macro_export]
 macro_rules! assert_ne {
     ($left:expr, $right:expr) => ({
-        assert_ne!(@ $left, $right, "", "");
+        $crate::assert_ne!(@ $left, $right, "", "");
     });
     ($left:expr, $right:expr,) => ({
-        assert_ne!(@ $left, $right, "", "");
+        $crate::assert_ne!(@ $left, $right, "", "");
     });
     ($left:expr, $right:expr, $($arg:tt)+) => ({
-        assert_ne!(@ $left, $right, ": ", $($arg)+);
+        $crate::assert_ne!(@ $left, $right, ": ", $($arg)+);
     });
     (@ $left:expr, $right:expr, $maybe_semicolon:expr, $($arg:tt)+) => ({
         match (&($left), &($right)) {

--- a/tests/assert_eq.rs
+++ b/tests/assert_eq.rs
@@ -1,9 +1,5 @@
 #![allow(clippy::eq_op)]
 
-#[allow(unused_imports)]
-use pretty_assertions::{assert_eq, assert_ne};
-extern crate difference;
-
 #[test]
 #[should_panic(expected = r#"assertion failed: `(left == right)`
 
@@ -40,7 +36,7 @@ fn assert_eq() {
         dolor: Ok("hey ho!".to_string()),
     });
 
-    assert_eq!(x, y);
+    pretty_assertions::assert_eq!(x, y);
 }
 
 #[test]
@@ -81,14 +77,14 @@ fn assert_eq_custom() {
         dolor: Ok("hey ho!".to_string()),
     });
 
-    assert_eq!(x, y, "custom panic message");
+    pretty_assertions::assert_eq!(x, y, "custom panic message");
 }
 
 #[test]
 fn assert_eq_with_comparable_types() {
     let s0: &'static str = "foo";
     let s1: String = "foo".to_string();
-    assert_eq!(s0, s1);
+    pretty_assertions::assert_eq!(s0, s1);
 }
 
 #[test]
@@ -113,7 +109,7 @@ fn assert_eq_with_comparable_types() {
 fn issue12() {
     let left = vec![0, 0, 0, 128, 10, 191, 5, 64];
     let right = vec![84, 248, 45, 64];
-    assert_eq!(left, right);
+    pretty_assertions::assert_eq!(left, right);
 }
 
 #[test]
@@ -152,7 +148,7 @@ fn assert_eq_trailing_comma() {
         dolor: Ok("hey ho!".to_string()),
     });
 
-    assert_eq!(x, y,);
+    pretty_assertions::assert_eq!(x, y,);
 }
 
 #[test]
@@ -193,13 +189,13 @@ fn assert_eq_custom_trailing_comma() {
         dolor: Ok("hey ho!".to_string()),
     });
 
-    assert_eq!(x, y, "custom panic message",);
+    pretty_assertions::assert_eq!(x, y, "custom panic message",);
 }
 
 #[test]
 fn assert_eq_unsized() {
     let a: &[u8] = b"e";
-    assert_eq!(*a, *a);
+    pretty_assertions::assert_eq!(*a, *a);
 }
 
 #[test]
@@ -215,5 +211,5 @@ fn assert_eq_unsized() {
 fn assert_eq_unsized_panic() {
     let a: &[u8] = b"e";
     let b: &[u8] = b"ee";
-    assert_eq!(*a, *b);
+    pretty_assertions::assert_eq!(*a, *b);
 }

--- a/tests/assert_ne.rs
+++ b/tests/assert_ne.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::eq_op)]
 
-#[allow(unused_imports)]
-use pretty_assertions::{assert_eq, assert_ne};
 #[test]
 #[should_panic(expected = r#"assertion failed: `(left != right)`
 
@@ -31,7 +29,7 @@ fn assert_ne() {
         dolor: Ok("hey".to_string()),
     });
 
-    assert_ne!(x, x);
+    pretty_assertions::assert_ne!(x, x);
 }
 
 #[test]
@@ -65,14 +63,14 @@ fn assert_ne_custom() {
         dolor: Ok("hey".to_string()),
     });
 
-    assert_ne!(x, x, "custom panic message");
+    pretty_assertions::assert_ne!(x, x, "custom panic message");
 }
 
 #[test]
 #[should_panic]
 fn assert_ne_non_empty_return() {
     fn not_zero(x: u32) -> u32 {
-        assert_ne!(x, 0);
+        pretty_assertions::assert_ne!(x, 0);
         x
     };
     not_zero(0);
@@ -106,7 +104,7 @@ fn assert_ne_partial() {
         }
     }
 
-    assert_ne!(Foo(-0.0), Foo(0.0));
+    pretty_assertions::assert_ne!(Foo(-0.0), Foo(0.0));
 }
 
 #[test]
@@ -138,7 +136,7 @@ fn assert_ne_trailing_comma() {
         dolor: Ok("hey".to_string()),
     });
 
-    assert_ne!(x, x,);
+    pretty_assertions::assert_ne!(x, x,);
 }
 
 #[test]
@@ -172,14 +170,14 @@ fn assert_ne_custom_trailing_comma() {
         dolor: Ok("hey".to_string()),
     });
 
-    assert_ne!(x, x, "custom panic message",);
+    pretty_assertions::assert_ne!(x, x, "custom panic message",);
 }
 
 #[test]
 fn assert_ne_unsized() {
     let a: &[u8] = b"e";
     let b: &[u8] = b"ee";
-    assert_ne!(*a, *b);
+    pretty_assertions::assert_ne!(*a, *b);
 }
 
 #[test]
@@ -193,5 +191,5 @@ fn assert_ne_unsized() {
 "#)]
 fn assert_ne_unsized_panic() {
     let a: &[u8] = b"e";
-    assert_ne!(*a, *a);
+    pretty_assertions::assert_ne!(*a, *a);
 }

--- a/tests/pretty_string.rs
+++ b/tests/pretty_string.rs
@@ -1,6 +1,5 @@
-#[allow(unused_imports)]
-use pretty_assertions::{assert_eq, assert_ne};
 use std::fmt;
+
 /// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
 /// Used in different `assert*!` macros in combination with `pretty_assertions` crate to make
 /// test failures to show nice diffs.
@@ -23,5 +22,5 @@ impl<'a> fmt::Debug for PrettyString<'a> {
 [0m
 "#)]
 fn assert_eq_empty_first() {
-    assert_eq!(PrettyString(""), PrettyString("foo"));
+    pretty_assertions::assert_eq!(PrettyString(""), PrettyString("foo"));
 }


### PR DESCRIPTION
Closes #41

Some macro expansions were not hygenic, and ended up referencing the standard library `assert_eq` and `assert_ne`. This was masked in tests by statements such as `use pretty_assertions::assert_eq` which masked the stdlib macros in tests.

Updated tests to remove these `use` statements, and audited the existing macro code for non-`$crate` qualified paths.