### PR TITLE
ci: clear cargo audit ignores

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -3,8 +3,7 @@
 set -exuo pipefail
 
 cargo fmt -- --check
-cargo audit --deny warnings \
-  --ignore RUSTSEC-2020-0095
+cargo audit --deny warnings
 cargo clippy --all-targets -- -D warnings
 cargo test
 cargo doc --no-deps


### PR DESCRIPTION
Ref #44; now we no longer depend on `difference`, we can stop ignoring the `cargo audit` warning for it.