### PR TITLE
ci: cache cargo binary installations

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
+            ~/.cargo/bin
             cargo_target
           key: detailed-test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install toolchain


### PR DESCRIPTION
For `cargo-audit` and `cargo-tarpaulin` (which still take a long time to install)