### PR TITLE
ci: add crate publish workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
             target
             ~/.cargo/bin
             cargo_target
-          key: detailed-test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: detailed-test-${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -74,7 +74,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: test-${{ matrix.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: test-${{ matrix.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            ~/.cargo/bin
+            cargo_target
+          # We reuse the cache from our detailed test environment, if available
+          key: detailed-test-{{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Publish crate
+        env:
+          CARGO_LOGIN_TOKEN: ${{ secrets.CARGO_LOGIN_TOKEN }}
+        run: ./scripts/publish

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cargo login "${CARGO_LOGIN_TOKEN}"
+cargo publish


### PR DESCRIPTION
Before use, the `CARGO_LOGIN_TOKEN` secret should be set in the repo settings to an appropriate value.