### PR TITLE
ci: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+cargo_target


### PR DESCRIPTION
To avoid `cargo publish` warning us that we have untracked files in our working directory.