### PR TITLE
test: add proptest to test diff input for crashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ diff = "0.1.12"
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"
 ctor = "0.1.9"
+
+[dev-dependencies]
+proptest = "1.0.0"

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -197,6 +197,30 @@ fn write_inline_diff<TWrite: fmt::Write>(f: &mut TWrite, left: &str, right: &str
 #[cfg(test)]
 mod test {
     use super::*;
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    /// Generate a random number of random lines, joined together with newline.
+    fn lines_strategy() -> BoxedStrategy<String> {
+        proptest::collection::vec("\\PC*", 1..16)
+            .prop_map(|vec| vec.join("\n"))
+            .boxed()
+    }
+
+    // Check our writer functions don't crash with random arbitrary input.
+    proptest! {
+        #[test]
+        fn write_inline_diff_arbitary(ref left in "\\PC*", ref right in "\\PC*") {
+            let mut f = String::new();
+            write_inline_diff(&mut f, left, right).unwrap();
+        }
+
+        #[test]
+        fn write_diff_arbitary(ref left in lines_strategy(), ref right in lines_strategy()) {
+            let mut f = String::new();
+            write_inline_diff(&mut f, left, right).unwrap();
+        }
+    }
 
     // ANSI terminal codes used in our outputs.
     //


### PR DESCRIPTION
To check for edge cases that may induce crashes on edge case input sequences.