### PR TITLE
feature: add assert_matches as unstable feature

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Install toolchain (nightly)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: false
       - name: Install additional test dependencies
         env:
           CARGO_TARGET_DIR: cargo_target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Adds the `unstable` feature to the `pretty_assertions` crate, for use with nightly rustc ([#81](https://github.com/colin-kiegel/rust-pretty-assertions/pull/81), [@tommilligan](https://github.com/tommilligan))
+- Add a drop in replacement for the unstable stdlib `assert_matches` macro, behind the `unstable` flag - thanks [@gilescope](https://github.com/gilescope) for the suggestion! ([#81](https://github.com/colin-kiegel/rust-pretty-assertions/issues/81), [@tommilligan](https://github.com/tommilligan))
+
 # v0.7.2
 
 - Fix macro hygiene for expansion in a `no_implicit_prelude` context ([#70](https://github.com/colin-kiegel/rust-pretty-assertions/issues/70), [@tommilligan](https://github.com/tommilligan))

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -17,8 +17,11 @@ categories = ["development-tools"]
 keywords = ["assert", "diff", "pretty", "color"]
 readme = "README.md"
 
-[badges]
-travis-ci = { repository = "colin-kiegel/rust-pretty-assertions" }
+[features]
+default = []
+
+# Enable unstable features requiring nightly rustc
+unstable = []
 
 [dependencies]
 ansi_term = "0.12.1"

--- a/pretty_assertions/tests/macros.rs
+++ b/pretty_assertions/tests/macros.rs
@@ -220,3 +220,89 @@ mod assert_ne {
         not_zero(0);
     }
 }
+
+#[cfg(feature = "unstable")]
+mod assert_matches {
+    use ::std::option::Option::{None, Some};
+
+    #[test]
+    fn passes() {
+        let a = Some("some value");
+        ::pretty_assertions::assert_matches!(a, Some(_));
+    }
+
+    #[test]
+    fn passes_unsized() {
+        let a: &[u8] = b"e";
+        ::pretty_assertions::assert_matches!(*a, _);
+    }
+
+    #[test]
+    #[should_panic(expected = r#"assertion failed: `(left matches right)`
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+[31m<[0m[1;48;5;52;31mN[0m[31mo[0m[1;48;5;52;31mn[0m[31me[0m
+[32m>[0m[1;48;5;22;32mS[0m[32mo[0m[1;48;5;22;32mm[0m[32me[0m[1;48;5;22;32m(_)[0m
+
+"#)]
+    fn fails() {
+        ::pretty_assertions::assert_matches!(None::<usize>, Some(_));
+    }
+
+    #[test]
+    #[should_panic(expected = r#"assertion failed: `(left matches right)`
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+[31m<Some([0m
+[31m<    3,[0m
+[31m<)[0m
+[32m>Some(3) if 0 > 0[0m
+
+"#)]
+    fn fails_guard() {
+        ::pretty_assertions::assert_matches!(Some(3), Some(3) if 0 > 0,);
+    }
+
+    #[test]
+    #[should_panic(expected = r#"assertion failed: `(left matches right)`
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+[31m<[[0m
+[31m<    101,[0m
+[31m<][0m
+[32m>ref b if b == b"ee"[0m
+
+"#)]
+    fn fails_unsized() {
+        let a: &[u8] = b"e";
+        ::pretty_assertions::assert_matches!(*a, ref b if b == b"ee");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = r#"assertion failed: `(left matches right)`: custom panic message
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+[31m<[0m[1;48;5;52;31m666[0m
+[32m>[0m[1;48;5;22;32m999[0m
+
+"#
+    )]
+    fn fails_custom() {
+        ::pretty_assertions::assert_matches!(666, 999, "custom panic message");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = r#"assertion failed: `(left matches right)`: custom panic message
+
+[1mDiff[0m [31m< left[0m / [32mright >[0m :
+[31m<[0m[1;48;5;52;31m666[0m
+[32m>[0m[1;48;5;22;32m999[0m
+
+"#
+    )]
+    fn fails_custom_trailing_comma() {
+        ::pretty_assertions::assert_matches!(666, 999, "custom panic message",);
+    }
+}

--- a/pretty_assertions_bench/Cargo.toml
+++ b/pretty_assertions_bench/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Tom Milligan <code@tommilligan.net>"]
 edition = "2018"
 
 [dependencies]
-criterion = { version = "0.3.4", features = ["html_reports"] }
+criterion = { version = "0.3.5", features = ["html_reports"] }
 pretty_assertions = { path = "../pretty_assertions" }
 
 [lib]

--- a/scripts/check
+++ b/scripts/check
@@ -18,6 +18,9 @@ cargo clippy --all-targets -- -D warnings
 eprintln "Running unit tests"
 cargo test
 
+eprintln "Running unit tests (unstable)"
+cargo +nightly test --manifest-path pretty_assertions/Cargo.toml --all --features unstable
+
 eprintln "Building documentation"
 cargo doc --no-deps
 


### PR DESCRIPTION
Closes #80 

Inlines the existing top level implementation of stdlib's `assert_matches`, and links it into our existing display framework. The results look... okay. Patterns don't come with nice multiline displaying, so we're mostly diffing a value against a pattern - but just getting them displayed in red/green and on separate lines is still nice.

![image](https://user-images.githubusercontent.com/12255914/129451743-3ec03c58-9970-4f83-bf6d-f6687dfa7da2.png)

@gilescope this was your suggestion, so will leave open for a bit if you have any further thoughts?