### PR TITLE
chore: include license text in crate artefact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixed
+
+- Ensure license text is included in crate archive - thanks [@decathorpe](https://github.com/decathorpe) for reporting this ([#87](https://github.com/colin-kiegel/rust-pretty-assertions/pull/87), [@tommilligan](https://github.com/tommilligan))
+
 # v1.0.0
 
 ## Removed

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -12,7 +12,7 @@ description = "Overwrite `assert_eq!` and `assert_ne!` with drop-in replacements
 repository = "https://github.com/colin-kiegel/rust-pretty-assertions"
 documentation = "https://docs.rs/pretty_assertions"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 categories = ["development-tools"]
 keywords = ["assert", "diff", "pretty", "color"]
 readme = "README.md"

--- a/pretty_assertions/LICENSE-APACHE
+++ b/pretty_assertions/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/pretty_assertions/LICENSE-MIT
+++ b/pretty_assertions/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/pretty_assertions_bench/Cargo.toml
+++ b/pretty_assertions_bench/Cargo.toml
@@ -3,6 +3,7 @@ name = "pretty_assertions_bench"
 version = "0.1.0"
 authors = ["Tom Milligan <code@tommilligan.net>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }

--- a/scripts/check
+++ b/scripts/check
@@ -10,7 +10,8 @@ eprintln "Formatting sources"
 cargo fmt -- --check
 
 eprintln "Auditing dependencies"
-cargo audit --deny warnings
+cargo audit --deny warnings \
+  --ignore RUSTSEC-2021-0127 # unmaintained serde_cbor
 
 eprintln "Linting sources"
 cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
Closes #86 

Includes license texts in the crate archive - these were omitted by mistake.

Also:
- Updates the license identifier to a valid SPDX identifier; use of `/` instead of ` OR ` is deprecated by cargo: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields.
- Prevent benchmarks from being accidentally published