### PR TITLE
Update dependency output_vt100

### DIFF
--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -34,6 +34,5 @@ ansi_term = "0.12.1"
 diff = "0.1.12"
 
 [target.'cfg(windows)'.dependencies]
-output_vt100 = "0.1.2"
+output_vt100 = "0.1.3"
 ctor = "0.1.9"
-


### PR DESCRIPTION
Update from version 0.1.2 to 0.1.3. This is a minor update that shouldn’t change the behavior of the library.